### PR TITLE
Operation outcome print

### DIFF
--- a/fhirpy/base/exceptions.py
+++ b/fhirpy/base/exceptions.py
@@ -1,3 +1,5 @@
+import json
+
 class BaseFHIRError(Exception):
     pass
 
@@ -16,13 +18,8 @@ class AuthorizationError(BaseFHIRError):
 
 class OperationOutcome(BaseFHIRError):
     def __init__(self, *args, **kwargs):
-        text: str = args[0]["text"]
-        text = text.removeprefix(
-            "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td><pre>").removesuffix(
-            "</pre></td>\n\t\t\t</tr>\n\t\t</table>\n\t</div>")
-        error = {"text": text,
-                 "issue": args[0]["issue"]}
-        super(args, kwargs)
+        error = json.loads(args[0])["issue"]
+        super().__init__(error, kwargs)
 
 
 class MultipleResourcesFound(BaseFHIRError):

--- a/fhirpy/base/exceptions.py
+++ b/fhirpy/base/exceptions.py
@@ -1,5 +1,6 @@
 import json
 
+
 class BaseFHIRError(Exception):
     pass
 

--- a/fhirpy/base/exceptions.py
+++ b/fhirpy/base/exceptions.py
@@ -15,7 +15,14 @@ class AuthorizationError(BaseFHIRError):
 
 
 class OperationOutcome(BaseFHIRError):
-    pass
+    def __init__(self, *args, **kwargs):
+        text: str = args[0]["text"]
+        text = text.removeprefix(
+            "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td><pre>").removesuffix(
+            "</pre></td>\n\t\t\t</tr>\n\t\t</table>\n\t</div>")
+        error = {"text": text,
+                 "issue": args[0]["issue"]}
+        super(args, kwargs)
 
 
 class MultipleResourcesFound(BaseFHIRError):


### PR DESCRIPTION
Copy of PR https://github.com/beda-software/fhir-py/pull/75 so that we can integrate it faster.

Copy of body:

A typical error may contain additional information like formatted output (HAPI) and it will report as this in sentry:

> {
  "resourceType": "OperationOutcome",
  "text": {
    "status": "generated",
    "div": "<div xmlns=\"http://www.w3.org/1999/xhtml\"><h1>Operation Outcome</h1><table border=\"0\"><tr><td style=\"font-weight: bold;\">ERROR</td><td>[]</td><td><pre>Failed to apply JSON patch to Patient/d0d848c4-b917-11ea-aabf-86fddcb4ced6: [element=&quot;value&quot;] Invalid attribute value &quot;&quot;: Attribute value must not be empty (&quot;&quot;)</pre></td>\n\t\t\t</tr>\n\t\t</table>\n\t</div>"
  },
  "issue": [ {
 ...
 
This change only reports the error message [as defined by the standard](http://hl7.org/fhir/2021May/operationoutcome.html).